### PR TITLE
Release 0.1.0

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: "stackhpc"
 name: "pulp"
-version: "0.0.2"
+version: "0.1.0"
 readme: "README.md"
 authors:
   - "Piotr Parczewski"


### PR DESCRIPTION
Release a newer version of the collection to the Galaxy. We didn't bump metadata in https://github.com/stackhpc/ansible-collection-pulp/pull/17.