### PR TITLE
pulp_distribution: sort repository versions numerically

### DIFF
--- a/plugins/filter/filters.py
+++ b/plugins/filter/filters.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2021 StackHPC Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+def sort_publications(pubs):
+    """Sort a list of publications by repository version.
+
+    Higher repository versions are listed first.
+    """
+    def key(pub):
+        # Format: /pulp/api/v3/repositories/rpm/rpm/<repo UUID>/versions/<version>/
+        rv = pub["repository_version"]
+        return int(rv.split("/")[-2])
+
+    return sorted(pubs, key=key, reverse=True)
+
+
+class FilterModule(object):
+
+    def filters(self):
+        return {
+            "sort_publications": sort_publications
+        }

--- a/roles/pulp_distribution/tasks/deb.yml
+++ b/roles/pulp_distribution/tasks/deb.yml
@@ -29,7 +29,7 @@
     # If the distribution references a specific version:
     specific_pub: "{{ pulp_pubs_list.publications | selectattr('repository_version', 'equalto', repo.pulp_href ~ 'versions/' ~ item.version | default ~ '/') }}"
     # If the distribution uses the latest version:
-    latest_pub: "{{ pulp_pubs_list.publications | selectattr('repository', 'equalto', repo.pulp_href) | sort(attribute='repository_version', reverse=True) }}"
+    latest_pub: "{{ pulp_pubs_list.publications | selectattr('repository', 'equalto', repo.pulp_href) | stackhpc.pulp.sort_publications }}"
     # If another distribution is being promoted to this one:
     promoted_dist: "{{ pulp_dists_list.distributions | selectattr('name', 'equalto', item.distribution | default) }}"
     promoted_pub: "{{ pulp_pubs_list.publications | selectattr('pulp_href', 'equalto', (promoted_dist | first).publication | default) }}"

--- a/roles/pulp_distribution/tasks/rpm.yml
+++ b/roles/pulp_distribution/tasks/rpm.yml
@@ -29,7 +29,7 @@
     # If the distribution references a specific version:
     specific_pub: "{{ pulp_pubs_list.publications | selectattr('repository_version', 'equalto', repo.pulp_href ~ 'versions/' ~ item.version | default ~ '/') }}"
     # If the distribution uses the latest version:
-    latest_pub: "{{ pulp_pubs_list.publications | selectattr('repository', 'equalto', repo.pulp_href) | sort(attribute='repository_version', reverse=True) }}"
+    latest_pub: "{{ pulp_pubs_list.publications | selectattr('repository', 'equalto', repo.pulp_href) | stackhpc.pulp.sort_publications }}"
     # If another distribution is being promoted to this one:
     promoted_dist: "{{ pulp_dists_list.distributions | selectattr('name', 'equalto', item.distribution | default) }}"
     promoted_pub: "{{ pulp_pubs_list.publications | selectattr('pulp_href', 'equalto', (promoted_dist | first).publication | default) }}"


### PR DESCRIPTION
When creating a distribution without specifying a repository version,
distribution or publication, the latest repository version should be used.
However, there is a text sort in the implementation which should be numerical.
This leads to choosing version 9 over version 10.

This change adds an Ansible filter to perform the sort correctly.

Fixes: #8