### PR TITLE
pulp_repository: add support for sync_policy for RPM syncs

### DIFF
--- a/roles/pulp_repository/tasks/rpm.yml
+++ b/roles/pulp_repository/tasks/rpm.yml
@@ -29,5 +29,6 @@
     validate_certs: "{{ pulp_validate_certs | bool }}"
     repository: "{{ item.name }}"
     remote: "{{ item.name }}-remote"
+    sync_policy: "{{ item.sync_policy | default(omit) }}"
   with_items: "{{  pulp_repository_rpm_repos }}"
   when: item.state == "present"


### PR DESCRIPTION
This can be used to enable mirror modes rather than the default additive
mode.

Depends on: https://github.com/pulp/squeezer/pull/86