### PR TITLE
pulp_distribution: add private flag to container distributions

### DIFF
--- a/roles/pulp_distribution/tasks/container.yml
+++ b/roles/pulp_distribution/tasks/container.yml
@@ -10,5 +10,6 @@
     repository: "{{ item.repository }}"
     version: "{{ item.version | default(omit) }}"
     content_guard: "{{ item.content_guard | default(omit) }}"
+    private: "{{ item.private | default(omit) }}"
     state: "{{ item.state }}"
   with_items: "{{ pulp_distribution_container }}"


### PR DESCRIPTION
Depends on: https://github.com/pulp/squeezer/pull/87