### PR TITLE
pulp_repository: support include_tags and exclude_tags for container remotes

### DIFF
--- a/roles/pulp_distribution/tasks/container.yml
+++ b/roles/pulp_distribution/tasks/container.yml
@@ -7,7 +7,7 @@
     validate_certs: "{{ pulp_validate_certs | bool }}"
     name: "{{ item.name }}"
     base_path: "{{ item.base_path }}"
-    repository: "{{ item.repository }}"
+    repository: "{{ item.repository | default(omit) }}"
     version: "{{ item.version | default(omit) }}"
     content_guard: "{{ item.content_guard | default(omit) }}"
     state: "{{ item.state }}"

--- a/roles/pulp_repository/tasks/container.yml
+++ b/roles/pulp_repository/tasks/container.yml
@@ -22,6 +22,8 @@
     client_cert: "{{ item.client_cert | default(omit) }}"
     client_key: "{{ item.client_key | default(omit) }}"
     download_concurrency: "{{ item.download_concurrency | default(omit) }}"
+    exclude_tags: "{{ item.exclude_tags | default(omit) }}"
+    include_tags: "{{ item.include_tags | default(omit) }}"
     policy: "{{ item.policy | default(omit) }}"
     proxy_url: "{{ item.proxy_url | default(omit) }}"
     proxy_username: "{{ item.proxy_username | default(omit) }}"


### PR DESCRIPTION
Depends on: https://github.com/pulp/squeezer/pull/89

Also make repository optional for container distributions .