### PR TITLE
pulp_repository: Fix remote removal with state=absent

### DIFF
--- a/roles/pulp_repository/tasks/container.yml
+++ b/roles/pulp_repository/tasks/container.yml
@@ -35,7 +35,7 @@
     url: "{{ item.url | default(omit) }}"
     state: "{{ item.state }}"
   with_items: "{{ pulp_repository_container_repos }}"
-  when: item.url is defined
+  when: item.state == "absent" or item.url is defined
   loop_control:
     label: "{{ item.name }}"
 

--- a/roles/pulp_repository/tasks/deb.yml
+++ b/roles/pulp_repository/tasks/deb.yml
@@ -35,7 +35,7 @@
     url: "{{ item.url | default(omit) }}"
     state: "{{ item.state }}"
   with_items: "{{ pulp_repository_deb_repos }}"
-  when: item.url is defined
+  when: item.state == "absent" or item.url is defined
   loop_control:
     label: "{{ item.name }}"
 

--- a/roles/pulp_repository/tasks/python.yml
+++ b/roles/pulp_repository/tasks/python.yml
@@ -35,7 +35,7 @@
     url: "{{ item.url | default(omit) }}"
     state: "{{ item.state }}"
   with_items: "{{ pulp_repository_python_repos }}"
-  when: item.url is defined
+  when: item.state == "absent" or item.url is defined
   loop_control:
     label: "{{ item.name }}"
 

--- a/roles/pulp_repository/tasks/rpm.yml
+++ b/roles/pulp_repository/tasks/rpm.yml
@@ -32,7 +32,7 @@
     url: "{{ item.url | default(omit) }}"
     state: "{{ item.state }}"
   with_items: "{{ pulp_repository_rpm_repos }}"
-  when: item.url is defined
+  when: item.state == "absent" or item.url is defined
   loop_control:
     label: "{{ item.name }}"
 


### PR DESCRIPTION
Since remotes were made optional, they no longer get removed when
state=absent. This change fixes the issue.