### PR TITLE
Prevent passwords and client keys being leaked when tasks fail

### DIFF
--- a/roles/pulp_content_guard/tasks/main.yml
+++ b/roles/pulp_content_guard/tasks/main.yml
@@ -5,13 +5,13 @@
     username: "{{ pulp_username }}"
     password: "{{ pulp_password }}"
     validate_certs: "{{ pulp_validate_certs | bool }}"
-    name: "{{ item.name }}"
-    description: "{{ item.description | default(omit) }}"
-    ca_certificate: "{{ item.ca_certificate | default(omit) }}"
-    state: "{{ item.state }}"
-  with_items: "{{ pulp_content_guard_x509_cert_guards }}"
+    name: "{{ pulp_content_guard_x509_cert_guards[cert_guard_index].name }}"
+    description: "{{ pulp_content_guard_x509_cert_guards[cert_guard_index].description | default(omit) }}"
+    ca_certificate: "{{ pulp_content_guard_x509_cert_guards[cert_guard_index].ca_certificate | default(omit) }}"
+    state: "{{ pulp_content_guard_x509_cert_guards[cert_guard_index].state }}"
+  loop: "{{ pulp_content_guard_x509_cert_guards | map(attribute='name') }}"
   loop_control:
-    label: "{{ item.name }}"
+    index_var: cert_guard_index
 
 - name: Ensure RBAC cert guards exist
   import_tasks: rbac/rbac.yml

--- a/roles/pulp_django_user/tasks/main.yml
+++ b/roles/pulp_django_user/tasks/main.yml
@@ -37,15 +37,15 @@
       Cookie: "{{ result_login.cookies_string }}"
     body:
       csrfmiddlewaretoken: "{{ result_login.cookies.csrftoken }}"
-      username: "{{ item.username }}"
-      password1: "{{ item.password }}"
-      password2: "{{ item.password }}"
+      username: "{{ pulp_django_users[user_index].username }}"
+      password1: "{{ pulp_django_users[user_index].password }}"
+      password2: "{{ pulp_django_users[user_index].password }}"
     body_format: form-urlencoded
     follow_redirects: all
     validate_certs: "{{ pulp_validate_certs | bool }}"
-  loop: "{{ pulp_django_users }}"
+  loop: "{{ pulp_django_users | map(attribute='username') }}"
   loop_control:
-    label: "{{ item.username }}"
+    index_var: user_index
 
 - name: Add or remove user from group(s)
   include_tasks: user_groups/add_or_remove_users.yml

--- a/roles/pulp_repository/tasks/container.yml
+++ b/roles/pulp_repository/tasks/container.yml
@@ -5,11 +5,11 @@
     username: "{{ pulp_username }}"
     password: "{{ pulp_password }}"
     validate_certs: "{{ pulp_validate_certs | bool }}"
-    name: "{{ item.name }}"
-    state: "{{ item.state }}"
-  with_items: "{{ pulp_repository_container_repos }}"
+    name: "{{ pulp_repository_container_repos[repository_index].name }}"
+    state: "{{ pulp_repository_container_repos[repository_index].state }}"
+    loop: "{{ pulp_repository_container_repos | map(attribute='name') }}"
   loop_control:
-    label: "{{ item.name }}"
+    index_var: repository_index
 
 - name: Setup container remotes
   pulp.squeezer.container_remote:
@@ -17,27 +17,29 @@
     username: "{{ pulp_username }}"
     password: "{{ pulp_password }}"
     validate_certs: "{{ pulp_validate_certs | bool }}"
-    name: "{{ item.name }}-remote"
-    ca_cert: "{{ item.ca_cert | default(omit) }}"
-    client_cert: "{{ item.client_cert | default(omit) }}"
-    client_key: "{{ item.client_key | default(omit) }}"
-    download_concurrency: "{{ item.download_concurrency | default(omit) }}"
-    exclude_tags: "{{ item.exclude_tags | default(omit) }}"
-    include_tags: "{{ item.include_tags | default(omit) }}"
-    policy: "{{ item.policy | default(omit) }}"
-    proxy_url: "{{ item.proxy_url | default(omit) }}"
-    proxy_username: "{{ item.proxy_username | default(omit) }}"
-    proxy_password: "{{ item.proxy_password | default(omit) }}"
-    remote_username: "{{ item.remote_username | default(omit) }}"
-    remote_password: "{{ item.remote_password | default(omit) }}"
-    tls_validation: "{{ item.tls_validation | default(omit) }}"
-    upstream_name: "{{ item.upstream_name | default(item.name) }}"
-    url: "{{ item.url | default(omit) }}"
-    state: "{{ item.state }}"
-  with_items: "{{ pulp_repository_container_repos }}"
-  when: item.state == "absent" or item.url is defined
+    name: "{{ pulp_repository_container_repos[repository_index].name }}-remote"
+    ca_cert: "{{ pulp_repository_container_repos[repository_index].ca_cert | default(omit) }}"
+    client_cert: "{{ pulp_repository_container_repos[repository_index].client_cert | default(omit) }}"
+    client_key: "{{ pulp_repository_container_repos[repository_index].client_key | default(omit) }}"
+    download_concurrency: "{{ pulp_repository_container_repos[repository_index].download_concurrency | default(omit) }}"
+    exclude_tags: "{{ pulp_repository_container_repos[repository_index].exclude_tags | default(omit) }}"
+    include_tags: "{{ pulp_repository_container_repos[repository_index].include_tags | default(omit) }}"
+    policy: "{{ pulp_repository_container_repos[repository_index].policy | default(omit) }}"
+    proxy_url: "{{ pulp_repository_container_repos[repository_index].proxy_url | default(omit) }}"
+    proxy_username: "{{ pulp_repository_container_repos[repository_index].proxy_username | default(omit) }}"
+    proxy_password: "{{ pulp_repository_container_repos[repository_index].proxy_password | default(omit) }}"
+    remote_username: "{{ pulp_repository_container_repos[repository_index].remote_username | default(omit) }}"
+    remote_password: "{{ pulp_repository_container_repos[repository_index].remote_password | default(omit) }}"
+    tls_validation: "{{ pulp_repository_container_repos[repository_index].tls_validation | default(omit) }}"
+    upstream_name: "{{ pulp_repository_container_repos[repository_index].upstream_name | default(pulp_repository_container_repos[repository_index].name) }}"
+    url: "{{ pulp_repository_container_repos[repository_index].url | default(omit) }}"
+    state: "{{ pulp_repository_container_repos[repository_index].state }}"
+  when: >
+    pulp_repository_container_repos[repository_index].state == "absent" or 
+    pulp_repository_container_repos[repository_index].url is defined
+  loop: "{{ pulp_repository_container_repos | map(attribute='name') }}"
   loop_control:
-    label: "{{ item.name }}"
+    index_var: repository_index
 
 - name: Sync container remotes into repositories
   pulp.squeezer.container_sync:
@@ -45,11 +47,11 @@
     username: "{{ pulp_username }}"
     password: "{{ pulp_password }}"
     validate_certs: "{{ pulp_validate_certs | bool }}"
-    repository: "{{ item.name }}"
-    remote: "{{ item.name }}-remote"
-  with_items: "{{ pulp_repository_container_repos }}"
+    repository: "{{ pulp_repository_container_repos[repository_index].name }}"
+    remote: "{{ pulp_repository_container_repos[repository_index].name }}-remote"
   when:
-    - item.url is defined
-    - item.state == "present"
+    - pulp_repository_container_repos[repository_index].url is defined
+    - pulp_repository_container_repos[repository_index].state == "present"
+  loop: "{{ pulp_repository_container_repos | map(attribute='name') }}"
   loop_control:
-    label: "{{ item.name }}"
+    index_var: repository_index

--- a/roles/pulp_repository/tasks/container.yml
+++ b/roles/pulp_repository/tasks/container.yml
@@ -7,7 +7,7 @@
     validate_certs: "{{ pulp_validate_certs | bool }}"
     name: "{{ pulp_repository_container_repos[repository_index].name }}"
     state: "{{ pulp_repository_container_repos[repository_index].state }}"
-    loop: "{{ pulp_repository_container_repos | map(attribute='name') }}"
+  loop: "{{ pulp_repository_container_repos | map(attribute='name') }}"
   loop_control:
     index_var: repository_index
 

--- a/roles/pulp_repository/tasks/deb.yml
+++ b/roles/pulp_repository/tasks/deb.yml
@@ -5,11 +5,11 @@
     username: "{{ pulp_username }}"
     password: "{{ pulp_password }}"
     validate_certs: "{{ pulp_validate_certs | bool }}"
-    name: "{{ item.name }}"
-    state: "{{ item.state }}"
-  with_items: "{{ pulp_repository_deb_repos }}"
+    name: "{{ pulp_repository_deb_repos[repository_index].name }}"
+    state: "{{ pulp_repository_deb_repos[repository_index].state }}"
+  loop: "{{ pulp_repository_deb_repos | map(attribute='name') }}"
   loop_control:
-    label: "{{ item.name }}"
+    index_var: repository_index
 
 - name: Setup DEB remotes
   pulp.squeezer.deb_remote:
@@ -17,27 +17,29 @@
     username: "{{ pulp_username }}"
     password: "{{ pulp_password }}"
     validate_certs: "{{ pulp_validate_certs | bool }}"
-    name: "{{ item.name }}-remote"
-    architectures: "{{ item.architectures | default(omit) }}"
-    ca_cert: "{{ item.ca_cert | default(omit) }}"
-    client_cert: "{{ item.client_cert | default(omit) }}"
-    client_key: "{{ item.client_key | default(omit) }}"
-    components: "{{ item.components | default(omit) }}"
-    distributions: "{{ item.distributions | default(omit) }}"
-    download_concurrency: "{{ item.download_concurrency | default(omit) }}"
-    policy: "{{ item.policy | default(omit) }}"
-    proxy_url: "{{ item.proxy_url | default(omit) }}"
-    proxy_username: "{{ item.proxy_username | default(omit) }}"
-    proxy_password: "{{ item.proxy_password | default(omit) }}"
-    remote_username: "{{ item.remote_username | default(omit) }}"
-    remote_password: "{{ item.remote_password | default(omit) }}"
-    tls_validation: "{{ item.tls_validation | default(omit) }}"
-    url: "{{ item.url | default(omit) }}"
-    state: "{{ item.state }}"
-  with_items: "{{ pulp_repository_deb_repos }}"
-  when: item.state == "absent" or item.url is defined
+    name: "{{ pulp_repository_deb_repos[repository_index].name }}-remote"
+    architectures: "{{ pulp_repository_deb_repos[repository_index].architectures | default(omit) }}"
+    ca_cert: "{{ pulp_repository_deb_repos[repository_index].ca_cert | default(omit) }}"
+    client_cert: "{{ pulp_repository_deb_repos[repository_index].client_cert | default(omit) }}"
+    client_key: "{{ pulp_repository_deb_repos[repository_index].client_key | default(omit) }}"
+    components: "{{ pulp_repository_deb_repos[repository_index].components | default(omit) }}"
+    distributions: "{{ pulp_repository_deb_repos[repository_index].distributions | default(omit) }}"
+    download_concurrency: "{{ pulp_repository_deb_repos[repository_index].download_concurrency | default(omit) }}"
+    policy: "{{ pulp_repository_deb_repos[repository_index].policy | default(omit) }}"
+    proxy_url: "{{ pulp_repository_deb_repos[repository_index].proxy_url | default(omit) }}"
+    proxy_username: "{{ pulp_repository_deb_repos[repository_index].proxy_username | default(omit) }}"
+    proxy_password: "{{ pulp_repository_deb_repos[repository_index].proxy_password | default(omit) }}"
+    remote_username: "{{ pulp_repository_deb_repos[repository_index].remote_username | default(omit) }}"
+    remote_password: "{{ pulp_repository_deb_repos[repository_index].remote_password | default(omit) }}"
+    tls_validation: "{{ pulp_repository_deb_repos[repository_index].tls_validation | default(omit) }}"
+    url: "{{ pulp_repository_deb_repos[repository_index].url | default(omit) }}"
+    state: "{{ pulp_repository_deb_repos[repository_index].state }}"
+  when: >
+    pulp_repository_deb_repos[repository_index].state == "absent" or 
+    pulp_repository_deb_repos[repository_index].url is defined
+  loop: "{{ pulp_repository_deb_repos | map(attribute='name') }}"
   loop_control:
-    label: "{{ item.name }}"
+    index_var: repository_index
 
 - name: Sync DEB remotes into repositories
   pulp.squeezer.deb_sync:
@@ -45,12 +47,12 @@
     username: "{{ pulp_username }}"
     password: "{{ pulp_password }}"
     validate_certs: "{{ pulp_validate_certs | bool }}"
-    repository: "{{ item.name }}"
-    remote: "{{ item.name }}-remote"
-    mirror: "{{ item.mirror | default(omit) }}"
-  with_items: "{{ pulp_repository_deb_repos }}"
+    repository: "{{ pulp_repository_deb_repos[repository_index].name }}"
+    remote: "{{ pulp_repository_deb_repos[repository_index].name }}-remote"
+    mirror: "{{ pulp_repository_deb_repos[repository_index].mirror | default(omit) }}"
   when:
-    - item.url is defined
-    - item.state == "present"
+    - pulp_repository_deb_repos[repository_index].url is defined
+    - pulp_repository_deb_repos[repository_index].state == "present"
+  loop: "{{ pulp_repository_deb_repos | map(attribute='name') }}"
   loop_control:
-    label: "{{ item.name }}"
+    index_var: repository_index

--- a/roles/pulp_repository/tasks/python.yml
+++ b/roles/pulp_repository/tasks/python.yml
@@ -5,11 +5,11 @@
     username: "{{ pulp_username }}"
     password: "{{ pulp_password }}"
     validate_certs: "{{ pulp_validate_certs | bool }}"
-    name: "{{ item.name }}"
-    state: "{{ item.state }}"
-  with_items: "{{ pulp_repository_python_repos }}"
+    name: "{{ pulp_repository_python_repos[repository_index].name }}"
+    state: "{{ pulp_repository_python_repos[repository_index].state }}"
+  loop: "{{ pulp_repository_python_repos | map(attribute='name') }}"
   loop_control:
-    label: "{{ item.name }}"
+    index_var: repository_index
 
 - name: Setup PyPI remotes
   pulp.squeezer.python_remote:
@@ -17,27 +17,29 @@
     username: "{{ pulp_username }}"
     password: "{{ pulp_password }}"
     validate_certs: "{{ pulp_validate_certs | bool }}"
-    name: "{{ item.name }}-remote"
-    ca_cert: "{{ item.ca_cert | default(omit) }}"
-    client_cert: "{{ item.client_cert | default(omit) }}"
-    client_key: "{{ item.client_key | default(omit) }}"
-    download_concurrency: "{{ item.download_concurrency | default(omit) }}"
-    excludes: "{{ item.excludes | default(omit) }}"
-    includes: "{{ item.includes | default(omit) }}"
-    policy: "{{ item.policy | default(omit) }}"
-    prereleases: "{{ item.prereleases | default(omit) }}"
-    proxy_url: "{{ item.proxy_url | default(omit) }}"
-    proxy_username: "{{ item.proxy_username | default(omit) }}"
-    proxy_password: "{{ item.proxy_password | default(omit) }}"
-    remote_username: "{{ item.remote_username | default(omit) }}"
-    remote_password: "{{ item.remote_password | default(omit) }}"
-    tls_validation: "{{ item.tls_validation | default(omit) }}"
-    url: "{{ item.url | default(omit) }}"
-    state: "{{ item.state }}"
-  with_items: "{{ pulp_repository_python_repos }}"
-  when: item.state == "absent" or item.url is defined
+    name: "{{ pulp_repository_python_repos[repository_index].name }}-remote"
+    ca_cert: "{{ pulp_repository_python_repos[repository_index].ca_cert | default(omit) }}"
+    client_cert: "{{ pulp_repository_python_repos[repository_index].client_cert | default(omit) }}"
+    client_key: "{{ pulp_repository_python_repos[repository_index].client_key | default(omit) }}"
+    download_concurrency: "{{ pulp_repository_python_repos[repository_index].download_concurrency | default(omit) }}"
+    excludes: "{{ pulp_repository_python_repos[repository_index].excludes | default(omit) }}"
+    includes: "{{ pulp_repository_python_repos[repository_index].includes | default(omit) }}"
+    policy: "{{ pulp_repository_python_repos[repository_index].policy | default(omit) }}"
+    prereleases: "{{ pulp_repository_python_repos[repository_index].prereleases | default(omit) }}"
+    proxy_url: "{{ pulp_repository_python_repos[repository_index].proxy_url | default(omit) }}"
+    proxy_username: "{{ pulp_repository_python_repos[repository_index].proxy_username | default(omit) }}"
+    proxy_password: "{{ pulp_repository_python_repos[repository_index].proxy_password | default(omit) }}"
+    remote_username: "{{ pulp_repository_python_repos[repository_index].remote_username | default(omit) }}"
+    remote_password: "{{ pulp_repository_python_repos[repository_index].remote_password | default(omit) }}"
+    tls_validation: "{{ pulp_repository_python_repos[repository_index].tls_validation | default(omit) }}"
+    url: "{{ pulp_repository_python_repos[repository_index].url | default(omit) }}"
+    state: "{{ pulp_repository_python_repos[repository_index].state }}"
+  when: >
+    pulp_repository_python_repos[repository_index].state == "absent" or 
+    pulp_repository_python_repos[repository_index].url is defined
+  loop: "{{ pulp_repository_python_repos | map(attribute='name') }}"
   loop_control:
-    label: "{{ item.name }}"
+    index_var: repository_index
 
 - name: Sync PyPI remotes into repositories
   pulp.squeezer.python_sync:
@@ -45,11 +47,11 @@
     username: "{{ pulp_username }}"
     password: "{{ pulp_password }}"
     validate_certs: "{{ pulp_validate_certs | bool }}"
-    repository: "{{ item.name }}"
-    remote: "{{ item.name }}-remote"
-  with_items: "{{ pulp_repository_python_repos }}"
+    repository: "{{ pulp_repository_python_repos[repository_index].name }}"
+    remote: "{{ pulp_repository_python_repos[repository_index].name }}-remote"
   when:
-    - item.url is defined
-    - item.state == "present"
+    - pulp_repository_python_repos[repository_index].url is defined
+    - pulp_repository_python_repos[repository_index].state == "present"
+  loop: "{{ pulp_repository_python_repos | map(attribute='name') }}"
   loop_control:
-    label: "{{ item.name }}"
+    index_var: repository_index

--- a/roles/pulp_repository/tasks/rpm.yml
+++ b/roles/pulp_repository/tasks/rpm.yml
@@ -36,7 +36,7 @@
     pulp_repository_rpm_repos[repository_index].url is defined
   loop: "{{ pulp_repository_rpm_repos | map(attribute='name') }}"
   loop_control:
-    index_var: repository_index"
+    index_var: repository_index
 
 - name: Sync RPM remotes into repositories
   pulp.squeezer.rpm_sync:
@@ -52,4 +52,4 @@
     - pulp_repository_rpm_repos[repository_index].state == "present"
   loop: "{{ pulp_repository_rpm_repos | map(attribute='name') }}"
   loop_control:
-    index_var: repository_index"
+    index_var: repository_index

--- a/roles/pulp_repository/tasks/rpm.yml
+++ b/roles/pulp_repository/tasks/rpm.yml
@@ -5,11 +5,11 @@
     username: "{{ pulp_username }}"
     password: "{{ pulp_password }}"
     validate_certs: "{{ pulp_validate_certs | bool }}"
-    name: "{{ item.name }}"
-    state: "{{ item.state }}"
-  with_items: "{{ pulp_repository_rpm_repos }}"
+    name: "{{ pulp_repository_rpm_repos[repository_index].name }}"
+    state: "{{ pulp_repository_rpm_repos[repository_index].state }}"
+  loop: "{{ pulp_repository_rpm_repos | map(attribute='name') }}"
   loop_control:
-    label: "{{ item.name }}"
+    index_var: repository_index"
 
 - name: Setup RPM remotes
   pulp.squeezer.rpm_remote:
@@ -17,24 +17,26 @@
     username: "{{ pulp_username }}"
     password: "{{ pulp_password }}"
     validate_certs: "{{ pulp_validate_certs | bool }}"
-    name: "{{ item.name }}-remote"
-    ca_cert: "{{ item.ca_cert | default(omit) }}"
-    client_cert: "{{ item.client_cert | default(omit) }}"
-    client_key: "{{ item.client_key | default(omit) }}"
-    download_concurrency: "{{ item.download_concurrency | default(omit) }}"
-    policy: "{{ item.policy | default(omit) }}"
-    proxy_url: "{{ item.proxy_url | default(omit) }}"
-    proxy_username: "{{ item.proxy_username | default(omit) }}"
-    proxy_password: "{{ item.proxy_password | default(omit) }}"
-    remote_username: "{{ item.remote_username | default(omit) }}"
-    remote_password: "{{ item.remote_password | default(omit) }}"
-    tls_validation: "{{ item.tls_validation | default(omit) }}"
-    url: "{{ item.url | default(omit) }}"
-    state: "{{ item.state }}"
-  with_items: "{{ pulp_repository_rpm_repos }}"
-  when: item.state == "absent" or item.url is defined
+    name: "{{ pulp_repository_rpm_repos[repository_index].name }}-remote"
+    ca_cert: "{{ pulp_repository_rpm_repos[repository_index].ca_cert | default(omit) }}"
+    client_cert: "{{ pulp_repository_rpm_repos[repository_index].client_cert | default(omit) }}"
+    client_key: "{{ pulp_repository_rpm_repos[repository_index].client_key | default(omit) }}"
+    download_concurrency: "{{ pulp_repository_rpm_repos[repository_index].download_concurrency | default(omit) }}"
+    policy: "{{ pulp_repository_rpm_repos[repository_index].policy | default(omit) }}"
+    proxy_url: "{{ pulp_repository_rpm_repos[repository_index].proxy_url | default(omit) }}"
+    proxy_username: "{{ pulp_repository_rpm_repos[repository_index].proxy_username | default(omit) }}"
+    proxy_password: "{{ pulp_repository_rpm_repos[repository_index].proxy_password | default(omit) }}"
+    remote_username: "{{ pulp_repository_rpm_repos[repository_index].remote_username | default(omit) }}"
+    remote_password: "{{ pulp_repository_rpm_repos[repository_index].remote_password | default(omit) }}"
+    tls_validation: "{{ pulp_repository_rpm_repos[repository_index].tls_validation | default(omit) }}"
+    url: "{{ pulp_repository_rpm_repos[repository_index].url | default(omit) }}"
+    state: "{{ pulp_repository_rpm_repos[repository_index].state }}"
+  when: >
+    pulp_repository_rpm_repos[repository_index].state == "absent" or 
+    pulp_repository_rpm_repos[repository_index].url is defined
+  loop: "{{ pulp_repository_rpm_repos | map(attribute='name') }}"
   loop_control:
-    label: "{{ item.name }}"
+    index_var: repository_index"
 
 - name: Sync RPM remotes into repositories
   pulp.squeezer.rpm_sync:
@@ -42,12 +44,12 @@
     username: "{{ pulp_username }}"
     password: "{{ pulp_password }}"
     validate_certs: "{{ pulp_validate_certs | bool }}"
-    repository: "{{ item.name }}"
-    remote: "{{ item.name }}-remote"
-    sync_policy: "{{ item.sync_policy | default(omit) }}"
-  with_items: "{{  pulp_repository_rpm_repos }}"
+    repository: "{{ pulp_repository_rpm_repos[repository_index].name }}"
+    remote: "{{ pulp_repository_rpm_repos[repository_index].name }}-remote"
+    sync_policy: "{{ pulp_repository_rpm_repos[repository_index].sync_policy | default(omit) }}"
   when:
-    - item.url is defined
-    - item.state == "present"
+    - pulp_repository_rpm_repos[repository_index].url is defined
+    - pulp_repository_rpm_repos[repository_index].state == "present"
+  loop: "{{ pulp_repository_rpm_repos | map(attribute='name') }}"
   loop_control:
-    label: "{{ item.name }}"
+    index_var: repository_index"

--- a/roles/pulp_repository/tasks/rpm.yml
+++ b/roles/pulp_repository/tasks/rpm.yml
@@ -9,7 +9,7 @@
     state: "{{ pulp_repository_rpm_repos[repository_index].state }}"
   loop: "{{ pulp_repository_rpm_repos | map(attribute='name') }}"
   loop_control:
-    index_var: repository_index"
+    index_var: repository_index
 
 - name: Setup RPM remotes
   pulp.squeezer.rpm_remote:


### PR DESCRIPTION
The original approach caused secrets to be leaked in the event of a task failing.

```
TASK [stackhpc.pulp.pulp_repository : Setup DEB repositories] *****************************************************************************************
Monday 21 November 2022  17:08:53 +0000 (0:00:00.024)       0:00:00.493 *******
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: urllib.error.URLError: <urlopen error timed out>
failed: [localhost] (item=Ubuntu focal) => changed=false
  ansible_loop_var: item
  item:
    architectures: amd64
    base_path: ubuntu/focal/
    components: main restricted universe multiverse
    distribution_name: ubuntu-focal-
    distributions: focal focal-updates focal-backports focal-security
    mirror: true
    mode: verbatim
    name: Ubuntu focal
    policy: on_demand
    publish: false
    short_name: ubuntu_focal
    state: present
    sync: false
    url: http://nova.clouds.archive.ubuntu.com/ubuntu/
  module_stderr: |-
    Traceback (most recent call last):
      File 
```

The new approach involves iterating over the map against an attribute that can be disclosed such as `name`. Combined with an `index_var` and the modules will still receive the information they require.