### PR TITLE
CI: Update versions used of community GitHub Actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,9 +20,9 @@ jobs:
           - "2.12"
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE, so it's accessible to the job
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
 
       - name: Install dependencies
         run: |
@@ -54,9 +54,9 @@ jobs:
           - "3.21"
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE, so it's accessible to the job
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
DEV-1359

Syncing the versions of community actions used to the latest major version.

This should avoid deprecation warnings seen in GitHub Actions.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
