### PR TITLE
Add retries to repo sync tasks

### DIFF
--- a/roles/pulp_repository/defaults/main.yml
+++ b/roles/pulp_repository/defaults/main.yml
@@ -8,3 +8,10 @@ pulp_repository_container_repos: []
 pulp_repository_deb_repos: []
 pulp_repository_python_repos: []
 pulp_repository_rpm_repos: []
+
+pulp_repository_sync_retries: 3
+
+pulp_repository_container_repos_sync_retries: "{{ pulp_repository_sync_retries }}"
+pulp_repository_deb_repos_sync_retries: "{{ pulp_repository_sync_retries }}"
+pulp_repository_python_repos_sync_retries: "{{ pulp_repository_sync_retries }}"
+pulp_repository_rpm_repos_sync_retries: "{{ pulp_repository_sync_retries }}"

--- a/roles/pulp_repository/tasks/container.yml
+++ b/roles/pulp_repository/tasks/container.yml
@@ -55,3 +55,7 @@
   loop: "{{ pulp_repository_container_repos | map(attribute='name') }}"
   loop_control:
     index_var: repository_index
+  register: pulp_repository_container_repos_sync
+  until: "pulp_repository_container_repos_sync is not failed" 
+  retries: "{{ pulp_repository_container_repos_sync_retries }}"
+  delay: 1

--- a/roles/pulp_repository/tasks/deb.yml
+++ b/roles/pulp_repository/tasks/deb.yml
@@ -56,3 +56,7 @@
   loop: "{{ pulp_repository_deb_repos | map(attribute='name') }}"
   loop_control:
     index_var: repository_index
+  register: pulp_repository_deb_repos_sync
+  until: "pulp_repository_deb_repos_sync is not failed" 
+  retries: "{{ pulp_repository_deb_repos_sync_retries }}"
+  delay: 1

--- a/roles/pulp_repository/tasks/python.yml
+++ b/roles/pulp_repository/tasks/python.yml
@@ -55,3 +55,8 @@
   loop: "{{ pulp_repository_python_repos | map(attribute='name') }}"
   loop_control:
     index_var: repository_index
+  register: pulp_repository_python_repos_sync
+  until: "pulp_repository_python_repos_sync is not failed" 
+  retries: "{{ pulp_repository_python_repos_sync_retries }}"
+  delay: 1
+

--- a/roles/pulp_repository/tasks/rpm.yml
+++ b/roles/pulp_repository/tasks/rpm.yml
@@ -53,3 +53,7 @@
   loop: "{{ pulp_repository_rpm_repos | map(attribute='name') }}"
   loop_control:
     index_var: repository_index
+  register: pulp_repository_rpm_repos_sync
+  until: "pulp_repository_rpm_repos_sync is not failed" 
+  retries: "{{ pulp_repository_rpm_repos_sync_retries }}"
+  delay: 1

--- a/tests/test_container_repository.yml
+++ b/tests/test_container_repository.yml
@@ -7,6 +7,7 @@
     pulp_username: admin
     pulp_password: password
     pulp_validate_certs: true
+    pulp_repository_container_repos_sync_retries: 2
   tasks:
     - include_role:
         name: pulp_repository
@@ -79,3 +80,36 @@
     - name: Verify remote deletion
       assert:
         that: container_remotes.remotes | length == 0
+
+    - block:
+      - include_role:
+          name: pulp_repository
+        vars:
+          pulp_repository_container_repos:
+            - name: test_container_repo_bad_url
+              upstream_name: pulp/test-fixture-1
+              url: "https://google.com/404"
+              policy: immediate
+              state: present
+
+      rescue:
+        - set_fact:
+            failed_task: "{{ ansible_failed_task }}"
+
+      always:
+        - name: Assert that syncing from a URL that returns 404 fails
+          assert:
+            that:
+              - failed_task.name == "Sync container remotes into repositories"
+
+        - name: Assert that syncing from a URL that returns 404 is retried the correct number of times
+          assert:
+            that:
+              - pulp_repository_container_repos_sync.results[0].attempts == pulp_repository_container_repos_sync_retries
+
+        - include_role:
+            name: pulp_repository
+          vars:
+            pulp_repository_deb_repos:
+            - name: test_container_repo_bad_url
+              state: absent

--- a/tests/test_deb_repository.yml
+++ b/tests/test_deb_repository.yml
@@ -7,6 +7,7 @@
     pulp_username: admin
     pulp_password: password
     pulp_validate_certs: true
+    pulp_repository_deb_repos_sync_retries: 2
   tasks:
     - include_role:
         name: pulp_repository
@@ -79,3 +80,35 @@
     - name: Verify remote deletion
       assert:
         that: deb_remotes.remotes | length == 0
+
+    - block:
+      - include_role:
+          name: pulp_repository
+        vars:
+          pulp_repository_deb_repos:
+            - name: test_deb_repo_bad_url
+              url: "https://google.com/404"
+              distributions: "ragnarok"
+              policy: immediate
+              state: present
+      rescue:
+        - set_fact:
+            failed_task: "{{ ansible_failed_task }}"
+
+      always:
+        - name: Assert that syncing from a URL that returns 404 fails
+          assert:
+            that:
+              - failed_task.name == "Sync DEB remotes into repositories"
+
+        - name: Assert that syncing from a URL that returns 404 is retried the correct number of times
+          assert:
+            that:
+              - pulp_repository_deb_repos_sync.results[0].attempts == pulp_repository_deb_repos_sync_retries
+
+        - include_role:
+            name: pulp_repository
+          vars:
+            pulp_repository_deb_repos:
+            - name: test_deb_repo_bad_url
+              state: absent

--- a/tests/test_rpm_repository.yml
+++ b/tests/test_rpm_repository.yml
@@ -7,6 +7,7 @@
     pulp_username: admin
     pulp_password: password
     pulp_validate_certs: true
+    pulp_repository_rpm_repos_sync_retries: 2
   tasks:
     - include_role:
         name: pulp_repository
@@ -77,3 +78,34 @@
     - name: Verify remote deletion
       assert:
         that: rpm_remotes.remotes | length == 0
+
+    - block:
+      - include_role:
+          name: pulp_repository
+        vars:
+          pulp_repository_rpm_repos:
+            - name: test_rpm_repo_bad_url
+              url: "https://google.com/404"
+              policy: immediate
+              state: present
+      rescue:
+        - set_fact:
+            failed_task: "{{ ansible_failed_task }}"
+
+      always:
+        - name: Assert that syncing from a URL that returns 404 fails
+          assert:
+            that:
+              - failed_task.name == "Sync RPM remotes into repositories"
+
+        - name: Assert that syncing from a URL that returns 404 is retried the correct number of times
+          assert:
+            that:
+              - pulp_repository_rpm_repos_sync.results[0].attempts == pulp_repository_rpm_repos_sync_retries
+
+        - include_role:
+            name: pulp_repository
+          vars:
+            pulp_repository_rpm_repos:
+            - name: test_rpm_repo_bad_url
+              state: absent


### PR DESCRIPTION
Sometimes repo sync tasks can fail for transient reasons like a bad mirror or network instability. Add retries to repository sync tasks to have another go at syncing.