### PR TITLE
pulp_container_content: Support state=read for container-push repos

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ansible==5.* jmespath
+          pip install ansible==5.* jmespath pulp-glue==0.21.*
           ansible-galaxy collection install git+file://$(pwd)
 
       - name: Run Pulp in one

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,8 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         pulp:
-          - "3.16"
           - "3.21"
+          - "3.45"
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE, so it's accessible to the job
       - uses: actions/checkout@v3

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@ namespace: stackhpc
 name: pulp
 description: >
   Roles and plugins Pulp repository server configuration
-version: "0.5.4"
+version: "0.5.5"
 readme: "README.md"
 authors:
   - "Piotr Parczewski"

--- a/plugins/modules/pulp_container_content.py
+++ b/plugins/modules/pulp_container_content.py
@@ -20,6 +20,11 @@ options:
       - Whether to allow missing tags when state is present.
     type: bool
     default: false
+  is_push:
+    description:
+      - Whether repository is a container-push repository.
+    type: bool
+    default: false
   src_repo:
     description:
       - Name of the repository to copy content from when state is present.
@@ -181,6 +186,8 @@ class PulpContainerRepositoryContent(PulpContainerRepository):
         self.get_content_units(self)
 
     def process(self):
+        if self.module.params["state"] == "read" and self.module.params["is_push"]:
+            self._list_id = "repositories_container_container_push_list"
         # Populate self.entity.
         self.find(failsafe=False)
         if self.module.params["state"] == "present":
@@ -198,6 +205,7 @@ def main():
     with PulpEntityAnsibleModule(
         argument_spec=dict(
             allow_missing={"type": "bool", "default": False},
+            is_push={"type": "bool", "default": False},
             repository={"required": True},
             src_repo={},
             src_is_push={"type": "bool", "default": False},

--- a/roles/pulp_container_content/tasks/main.yml
+++ b/roles/pulp_container_content/tasks/main.yml
@@ -6,6 +6,7 @@
     password: "{{ pulp_password }}"
     validate_certs: "{{ pulp_validate_certs | bool }}"
     allow_missing: "{{ item.allow_missing | default(omit) }}"
+    is_push: "{{ item.is_push | default(omit) }}"
     src_repo: "{{ item.src_repo | default(omit) }}"
     src_is_push: "{{ item.src_is_push | default(omit) }}"
     repository: "{{ item.repository }}"

--- a/tests/pulp-in-one.sh
+++ b/tests/pulp-in-one.sh
@@ -8,7 +8,7 @@ set -o pipefail
 
 mkdir -p settings
 
-PULP_TAG=${PULP_TAG:-"3.21"}
+PULP_TAG=${PULP_TAG:-"3.45"}
 
 cat << EOF > settings/settings.py
 CONTENT_ORIGIN='http://$(hostname):8080'


### PR DESCRIPTION
This allows us to check whether a tag exists in a container-push repository.
