### PR TITLE
Change collection version to 0.6.0

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@ namespace: stackhpc
 name: pulp
 description: >
   Roles and plugins Pulp repository server configuration
-version: "0.7.0"
+version: "0.6.0"
 readme: "README.md"
 authors:
   - "Piotr Parczewski"


### PR DESCRIPTION
Version was bumped before 0.6.0 was released, so it doesn't make sense for us to release 0.7.0 now. Reverting that change so we can just release this as 0.6.0.
