### PR TITLE
Support configuring a pypi pull-through cache

### DIFF
--- a/roles/pulp_distribution/README.md
+++ b/roles/pulp_distribution/README.md
@@ -12,6 +12,7 @@ Role variables
 * `pulp_validate_certs`: Whether to validate Pulp server certificate. Default is `true`
 * `pulp_distribution_container`: List of distributions for container repositories. Default is an empty list
 * `pulp_distribution_deb`: List of distributions for Deb repositories. Default is an empty list
+* `pulp_distribution_python`: List of distributions for Python repositories. Default is an empty list
 * `pulp_distribution_rpm`: List of distributions for RPM repositories. Default is an empty list
 * `pulp_distribution_deb_skip_existing`: Whether to skip existing Deb
   distributions. If true, new distributions will not be created for a
@@ -66,6 +67,18 @@ Example playbook
           base_path: ubuntu-focal-production
           distribution: ubuntu-focal
           content_guard: secure-content-guard
+          state: present
+      pulp_distribution_python:
+        # specify a remote to make a pull-through cache
+        - name: pull_through_distribution
+          base_path: pullthrough
+          repository: test_python_repo
+          remote: test_python_repo-remote
+          state: present
+        # without remote it automatically serves the latest version of the repository
+        - name: latest_version_distribution
+          base_path: latest
+          repository: test_python_repo
           state: present
       pulp_distribution_rpm:
         # Distribute the latest version of the centos-baseos repository.

--- a/roles/pulp_distribution/defaults/main.yml
+++ b/roles/pulp_distribution/defaults/main.yml
@@ -6,6 +6,7 @@ pulp_validate_certs: true
 
 pulp_distribution_container: []
 pulp_distribution_deb: []
+pulp_distribution_python: []
 pulp_distribution_rpm: []
 
 # Whether to skip existing distributions. If true, new distributions will

--- a/roles/pulp_distribution/tasks/main.yml
+++ b/roles/pulp_distribution/tasks/main.yml
@@ -9,6 +9,10 @@
   tags: deb
   when: pulp_distribution_deb | length > 0
 
+- include_tasks: python.yml
+  tags: python
+  when: pulp_distribution_python | length > 0
+
 - include_tasks: rpm.yml
   tags: rpm
   when: pulp_distribution_rpm | length > 0

--- a/roles/pulp_distribution/tasks/python.yml
+++ b/roles/pulp_distribution/tasks/python.yml
@@ -1,0 +1,14 @@
+---
+- name: Ensure Python distributions are defined
+  pulp.squeezer.python_distribution:
+    pulp_url: "{{ pulp_url }}"
+    username: "{{ pulp_username }}"
+    password: "{{ pulp_password }}"
+    validate_certs: "{{ pulp_validate_certs | bool }}"
+    name: "{{ item.name }}"
+    base_path: "{{ item.base_path | default(omit) }}"
+    content_guard: "{{ item.content_guard | default(omit) }}"
+    remote: "{{ (item.remote | default(omit)) if item.state == 'present' else omit }}"
+    repository: "{{ item.repository if item.state == 'present' else omit }}"
+    state: "{{ item.state }}"
+  with_items: "{{ pulp_distribution_python }}"

--- a/roles/pulp_repository/README.md
+++ b/roles/pulp_repository/README.md
@@ -52,4 +52,10 @@ Example playbook
           architectures: amd64
           policy: on_demand
           state: present
+      pulp_repository_python_repos:
+        - name: pypi
+          url: https://pypi.org/
+          policy: on_demand
+          state: present
+          sync: false
 ```

--- a/roles/pulp_repository/tasks/python.yml
+++ b/roles/pulp_repository/tasks/python.yml
@@ -60,6 +60,7 @@
   when:
     - pulp_repository_python_repos[repository_index].url is defined
     - pulp_repository_python_repos[repository_index].state == "present"
+    - pulp_repository_python_repos[repository_index].sync | default(True)
   loop: "{{ pulp_repository_python_repos | map(attribute='name') }}"
   loop_control:
     index_var: repository_index

--- a/tests/test_python_distribution.yml
+++ b/tests/test_python_distribution.yml
@@ -1,0 +1,200 @@
+---
+- name: Test pulp_distribution python
+  gather_facts: false
+  hosts: localhost
+  vars:
+    pulp_url: http://localhost:8080
+    pulp_username: admin
+    pulp_password: password
+    pulp_validate_certs: true
+  tasks:
+    - include_role:
+        name: pulp_repository
+      vars:
+        pulp_repository_python_repos:
+          - name: test_python_repo
+            url: "https://fixtures.pulpproject.org/python-pypi/"
+            policy: immediate
+            state: present
+            sync: false
+
+    - include_role:
+        name: pulp_distribution
+      vars:
+        pulp_distribution_python:
+          - name: test_python_distribution
+            base_path: test_python_distribution
+            repository: test_python_repo
+            remote: test_python_repo-remote
+            state: present
+
+    - name: Query repository
+      pulp.squeezer.python_repository:
+        pulp_url: "{{ pulp_url }}"
+        username: "{{ pulp_username }}"
+        password: "{{ pulp_password }}"
+        validate_certs: "{{ pulp_validate_certs }}"
+        name: test_python_repo
+      register: repo_result
+
+    - name: Query distribution
+      pulp.squeezer.python_distribution:
+        pulp_url: "{{ pulp_url }}"
+        username: "{{ pulp_username }}"
+        password: "{{ pulp_password }}"
+        validate_certs: "{{ pulp_validate_certs }}"
+        name: test_python_distribution
+      register: dist_result
+
+    - debug:
+        var: dist_result
+
+    - name: Verify distribution creation
+      assert:
+        that:
+          - dist_result.distribution.name == "test_python_distribution"
+          - dist_result.distribution.base_path == "test_python_distribution"
+
+    - name: Query distribution package index
+      ansible.builtin.uri:
+        url: "{{ pulp_url }}{{ dist_result.distribution.base_url | ansible.builtin.urlsplit('path') }}simple/"
+        return_content: true
+      register: package_index
+
+    - debug:
+        var: package_index
+
+    - name: Verify package index
+      ansible.builtin.assert:
+        that:
+          - package_index.status == 200
+          - "'Simple Index' in package_index.content"
+          - "'shelf-reader' not in package_index.content"  # gets pulled-through later on
+
+    - name: Query shelf-reader from distribution
+      ansible.builtin.uri:
+        url: "{{ pulp_url }}{{ dist_result.distribution.base_url | ansible.builtin.urlsplit('path') }}simple/shelf-reader/"
+        return_content: true
+      register: package_index
+
+    - name: Verify package index
+      ansible.builtin.assert:
+        that:
+          - package_index.status == 200
+          - "'shelf-reader-0.1.tar.gz' in package_index.content"
+          - "'shelf_reader-0.1-py2-none-any.whl' in package_index.content"
+
+    - include_role:
+        name: pulp_distribution
+      vars:
+        pulp_distribution_python:
+          - name: test_python_distribution
+            state: absent
+
+    - include_role:
+        name: pulp_repository
+      vars:
+        pulp_repository_python_repos:
+          - name: test_python_repo
+            state: absent
+
+    - name: Query distributions
+      pulp.squeezer.python_distribution:
+        pulp_url: "{{ pulp_url }}"
+        username: "{{ pulp_username }}"
+        password: "{{ pulp_password }}"
+        validate_certs: "{{ pulp_validate_certs }}"
+      register: python_distributions
+
+    - name: Verify distribution deletion
+      assert:
+        that: python_distributions.distributions | length == 0
+
+    # ---- test distribution serving latest version
+    - include_role:
+        name: pulp_repository
+      vars:
+        pulp_repository_python_repos:
+          - name: test_python_repo
+            url: "https://fixtures.pulpproject.org/python-pypi/"
+            policy: immediate
+            state: present
+            includes: ["shelf-reader"]
+
+    - include_role:
+        name: pulp_distribution
+      vars:
+        pulp_distribution_python:
+          - name: test_python_distribution
+            base_path: test_python_distribution
+            repository: test_python_repo
+            state: present
+
+    - name: Query repository
+      pulp.squeezer.python_repository:
+        pulp_url: "{{ pulp_url }}"
+        username: "{{ pulp_username }}"
+        password: "{{ pulp_password }}"
+        validate_certs: "{{ pulp_validate_certs }}"
+        name: test_python_repo
+      register: repo_result
+
+    - name: Query distribution
+      pulp.squeezer.python_distribution:
+        pulp_url: "{{ pulp_url }}"
+        username: "{{ pulp_username }}"
+        password: "{{ pulp_password }}"
+        validate_certs: "{{ pulp_validate_certs }}"
+        name: test_python_distribution
+      register: dist_result
+
+    - debug:
+        var: dist_result
+
+    - name: Verify distribution creation
+      assert:
+        that:
+          - dist_result.distribution.name == "test_python_distribution"
+          - dist_result.distribution.base_path == "test_python_distribution"
+
+    - name: Query distribution package index
+      ansible.builtin.uri:
+        url: "{{ pulp_url }}{{ dist_result.distribution.base_url | ansible.builtin.urlsplit('path') }}simple/"
+        return_content: true
+      register: package_index
+
+    - debug:
+        var: package_index
+
+    - name: Verify package index
+      ansible.builtin.assert:
+        that:
+          - package_index.status == 200
+          - "'Simple Index' in package_index.content"
+          - "'shelf-reader' in package_index.content"  # already there because the repository is synced
+
+    - include_role:
+        name: pulp_distribution
+      vars:
+        pulp_distribution_python:
+          - name: test_python_distribution
+            state: absent
+
+    - include_role:
+        name: pulp_repository
+      vars:
+        pulp_repository_python_repos:
+          - name: test_python_repo
+            state: absent
+
+    - name: Query distributions
+      pulp.squeezer.python_distribution:
+        pulp_url: "{{ pulp_url }}"
+        username: "{{ pulp_username }}"
+        password: "{{ pulp_password }}"
+        validate_certs: "{{ pulp_validate_certs }}"
+      register: python_distributions
+
+    - name: Verify distribution deletion
+      assert:
+        that: python_distributions.distributions | length == 0

--- a/tests/test_python_repository.yml
+++ b/tests/test_python_repository.yml
@@ -1,0 +1,202 @@
+---
+- name: Test pulp_repository python
+  gather_facts: false
+  hosts: localhost
+  vars:
+    pulp_url: http://localhost:8080
+    pulp_username: admin
+    pulp_password: password
+    pulp_validate_certs: true
+    pulp_repository_python_repos_sync_retries: 2
+  tasks:
+    - name: Create test_python_repo
+      include_role:
+        name: pulp_repository
+      vars:
+        pulp_repository_python_repos:
+          - name: test_python_repo
+            # trailing slash is mandatory
+            url: "https://fixtures.pulpproject.org/python-pypi/"
+            policy: immediate
+            state: present
+            includes: ["shelf-reader"]
+
+    - name: Query repository
+      pulp.squeezer.python_repository:
+        pulp_url: "{{ pulp_url }}"
+        username: "{{ pulp_username }}"
+        password: "{{ pulp_password }}"
+        validate_certs: "{{ pulp_validate_certs }}"
+        name: test_python_repo
+      register: repo_result
+
+    - name: Verify repository creation
+      assert:
+        that:
+          - repo_result.repository.name == "test_python_repo"
+
+    - name: Query remote
+      pulp.squeezer.python_remote:
+        pulp_url: "{{ pulp_url }}"
+        username: "{{ pulp_username }}"
+        password: "{{ pulp_password }}"
+        validate_certs: "{{ pulp_validate_certs }}"
+        name: test_python_repo-remote
+      register: remote_result
+
+    - name: Verify remote creation
+      assert:
+        that:
+          - remote_result.remote.name == "test_python_repo-remote"
+          - remote_result.remote.url == "https://fixtures.pulpproject.org/python-pypi/"
+          - remote_result.remote.policy == "immediate"
+
+    - name: Query content
+      pulp.squeezer.api_call:
+        pulp_url: "{{ pulp_url }}"
+        username: "{{ pulp_username }}"
+        password: "{{ pulp_password }}"
+        validate_certs: "{{ pulp_validate_certs }}"
+        operation_id: content_python_packages_list
+        parameters:
+          repository_version: "{{ repo_result.repository.latest_version_href }}"
+      register: content_result
+
+    - name: Verify synced content
+      assert:
+        that:
+          - content_result.response.count == 2
+          - content_result.response.results[0].filename == "shelf_reader-0.1-py2-none-any.whl"
+        fail_msg: |
+          count: {{  content_result.response.count }}
+          filenames: {% for r in content_result.response.results %}{{ r.filename }} {% endfor %}
+
+    - name: Delete test_python_repo
+      include_role:
+        name: pulp_repository
+      vars:
+        pulp_repository_python_repos:
+          - name: test_python_repo
+            state: absent
+
+    - name: Query repositories
+      pulp.squeezer.python_repository:
+        pulp_url: "{{ pulp_url }}"
+        username: "{{ pulp_username }}"
+        password: "{{ pulp_password }}"
+        validate_certs: "{{ pulp_validate_certs }}"
+      register: python_repositories
+
+    - name: Verify repository deletion
+      assert:
+        that: python_repositories.repositories | length == 0
+
+    - name: Query remotes
+      pulp.squeezer.python_remote:
+        pulp_url: "{{ pulp_url }}"
+        username: "{{ pulp_username }}"
+        password: "{{ pulp_password }}"
+        validate_certs: "{{ pulp_validate_certs }}"
+      register: python_remotes
+
+    - name: Verify remote deletion
+      assert:
+        that: python_remotes.remotes | length == 0
+
+    # ------------- TEST no sync -------------
+    - include_role:
+        name: pulp_repository
+      vars:
+        pulp_repository_python_repos:
+          # reuse previous repo name to simplify 'Verify repository deletion'
+          - name: test_python_repo
+            url: "https://fixtures.pulpproject.org/python-pypi/"
+            policy: immediate
+            state: present
+            sync: false  # changed parameter from default true
+            includes: ["shelf-reader"]
+
+    - name: Query repository
+      pulp.squeezer.python_repository:
+        pulp_url: "{{ pulp_url }}"
+        username: "{{ pulp_username }}"
+        password: "{{ pulp_password }}"
+        validate_certs: "{{ pulp_validate_certs }}"
+        name: test_python_repo
+      register: repo_result
+
+    - name: Verify repository creation
+      assert:
+        that:
+          - repo_result.repository.name == "test_python_repo"
+
+    - name: Query remote
+      pulp.squeezer.python_remote:
+        pulp_url: "{{ pulp_url }}"
+        username: "{{ pulp_username }}"
+        password: "{{ pulp_password }}"
+        validate_certs: "{{ pulp_validate_certs }}"
+        name: test_python_repo-remote
+      register: remote_result
+
+    - name: Verify remote creation
+      assert:
+        that:
+          - remote_result.remote.name == "test_python_repo-remote"
+          - remote_result.remote.url == "https://fixtures.pulpproject.org/python-pypi/"
+          - remote_result.remote.policy == "immediate"
+
+    - name: Query content (no synced content)
+      pulp.squeezer.api_call:
+        pulp_url: "{{ pulp_url }}"
+        username: "{{ pulp_username }}"
+        password: "{{ pulp_password }}"
+        validate_certs: "{{ pulp_validate_certs }}"
+        operation_id: content_python_packages_list
+        parameters:
+          repository_version: "{{ repo_result.repository.latest_version_href }}"
+      register: content_result
+
+    - debug:
+        var: content_result
+
+    - name: Verify no synced content
+      assert:
+        that:
+          - content_result.response.count == 0
+          - content_result.response.results | length == 0
+        fail_msg: |
+          count: {{  content_result.response.count }}
+          filenames: {% for r in content_result.response.results %}{{ r.filename }} {% endfor %}
+
+    - name: Delete test_python_repo
+      include_role:
+        name: pulp_repository
+      vars:
+        pulp_repository_python_repos:
+          - name: test_python_repo
+            state: absent
+
+    - name: Query repositories
+      pulp.squeezer.python_repository:
+        pulp_url: "{{ pulp_url }}"
+        username: "{{ pulp_username }}"
+        password: "{{ pulp_password }}"
+        validate_certs: "{{ pulp_validate_certs }}"
+      register: python_repositories
+
+    - name: Verify repository deletion
+      assert:
+        that: python_repositories.repositories | length == 0
+
+    - name: Query remotes
+      pulp.squeezer.python_remote:
+        pulp_url: "{{ pulp_url }}"
+        username: "{{ pulp_username }}"
+        password: "{{ pulp_password }}"
+        validate_certs: "{{ pulp_validate_certs }}"
+      register: python_remotes
+
+    - name: Verify remote deletion
+      assert:
+        that: python_remotes.remotes | length == 0


### PR DESCRIPTION
This needs to disable sync with remote to be useable (would start pulling the whole pypi archive otherwise).

python code for pulp_distribution has been written in a non-parallel way, because there is usually a single python repo (pypi).

Example tasks:

```
    - include_role:
        name: stackhpc.pulp.pulp_repository
      vars:
        pulp_repository_python_repos:
          - name: pypi
            url: "https://pypi.org/"
            state: present
            sync: false

    - include_role:
        name: stackhpc.pulp.pulp_distribution
      vars:
        pulp_distribution_python:
          - name: pypi-cache
            base_path: pypi
            repository: pypi
            remote: pypi-remote
            state: present
```